### PR TITLE
Handle empty tags directory more cleanly; clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tag And Warp
 
-Easily tag locations in deep space (directories) and easily warp (like the space drive) to them with a few keystrokes.
+Easily tag locations in deep space (directories) and warp (like the space drive) to them with a few keystrokes.
 
 ## Installation
 
@@ -10,13 +10,30 @@ Installation is quite straightforward. Depending on the shell you are using (bas
 
 ## Usage
 
+Basic usage example:
+
+```bash
+$ cd /var/log/
+$ tag logdir
+[INFO]: Tagged logdir as /var/log
+$ cd ~  # go somewhere else
+$ tags
+Listing available tags and destinations:
+
+log -> /var/log
+
+$ warp log
+[INFO]: Warping to /var/log.
+$ pwd
+/var/log
+```
+
 ### tag
 
 Tags the current directory with an optional tagname. If no tagname is specified it will take the name of the current directory.
 
 ```bash
 tag [tagname]
-warp [tagname]  # immediately jump into the tagged directory
 ```
 
 ### untag
@@ -31,6 +48,8 @@ This tagname is optional. If you are in a tagged directory it will automatically
 
 ### warp
 
+Jump to the tagged directory.
+
 ```bash
 warp [tagname]
 ```
@@ -38,6 +57,10 @@ warp [tagname]
 ### tags
 
 Lists all tags.
+
+```bash
+tags
+```
 
 ### retag
 
@@ -55,7 +78,6 @@ Some examples:
 retag mydir           # retags current tagged directory to `mydir`
 retag thisdir mydir   # retags `thisdir` to `mydir`
 ```
-
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Installation is quite straightforward. Depending on the shell you are using (bas
 Tags the current directory with an optional tagname. If no tagname is specified it will take the name of the current directory.
 
 ```bash
-warp [tagname]
+tag [tagname]
+warp [tagname]  # immediately jump into the tagged directory
 ```
 
 ### untag

--- a/src/.warpdrive
+++ b/src/.warpdrive
@@ -16,6 +16,7 @@ reset_colors='tput sgr0'
 
 # Define tags location.
 export WARP_LOCATIONS=$HOME/.tags
+mkdir -p "$WARP_LOCATIONS"
 
 ## END Definitions. ############################################################
 
@@ -205,7 +206,11 @@ function retag {
 }
 
 function tags {
-    echo "$(eval $set_bold)Listing available tags and destinations:$(eval $reset_colors)"
-    ls -l $WARP_LOCATIONS | sed 's/  / /g' | cut -d' ' -f9- && echo
-    eval $reset_colors
+    if [ -z "$(ls -A $WARP_LOCATIONS)" ]; then
+        echo "No tags available. Create a tag like so: 'tag [tagname]'"
+    else
+        echo "$(eval $set_bold)Listing available tags and destinations:$(eval $reset_colors)"
+        ls -l $WARP_LOCATIONS | sed 's/  / /g' | cut -d' ' -f9- && echo
+        eval $reset_colors
+    fi
 }


### PR DESCRIPTION
This pull request makes a few small changes:

- Creates the tags directory if it doesn't exist whenever warpdrive is sourced (`mkdir -p $HOME/.tags`). This means that the .tags directory won't be missing if a user runs `tags` before having ever created a tag.
- Checks whether or not the .tags directory is empty when a user runs the `tags` command. If the directory is empty, a nice message is shown to let the user know. Previously, a nasty missing directory error would appear.
- Add a full example (with stdout) and other small grammatical changes to the README so that general usage of this tool is a bit clearer.